### PR TITLE
42 login get endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "jsonwebtoken": "^9.0.2",
         "mongoose": "^7.6.8",
         "next": "^14.1.0",
+        "node": "^21.6.2",
         "react": "^18",
         "react-dom": "^18"
       },
@@ -3088,10 +3089,30 @@
         }
       }
     },
+    "node_modules/node": {
+      "version": "21.6.2",
+      "resolved": "https://registry.npmjs.org/node/-/node-21.6.2.tgz",
+      "integrity": "sha512-QdY/IILdqFN4yLJxG4u9njJ37FqBB7QLIkX6YuhOEx77HwgXXzEJOwhxHtEZevAbVt/sy7JIwIZJMgpijyGGxQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "node-bin-setup": "^1.0.0"
+      },
+      "bin": {
+        "node": "bin/node"
+      },
+      "engines": {
+        "npm": ">=5.0.0"
+      }
+    },
     "node_modules/node-addon-api": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
       "integrity": "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA=="
+    },
+    "node_modules/node-bin-setup": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/node-bin-setup/-/node-bin-setup-1.1.3.tgz",
+      "integrity": "sha512-opgw9iSCAzT2+6wJOETCpeRYAQxSopqQ2z+N6BXwIMsQQ7Zj5M8MaafQY8JMlolRR6R1UXg2WmhKp0p9lSOivg=="
     },
     "node_modules/node-fetch": {
       "version": "2.7.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^7.6.8",
     "next": "^14.1.0",
+    "node": "^21.6.2",
     "react": "^18",
     "react-dom": "^18"
   },

--- a/src/app/api/login/route.ts
+++ b/src/app/api/login/route.ts
@@ -3,7 +3,7 @@ import { NextRequest, NextResponse } from "next/server";
 import Users, { IUser } from "@database/userSchema";
 const bcrypt = require("bcrypt"); 
 
-export async function GET(req: NextRequest) {
+export async function POST(req: NextRequest) {
     await connectDB();
     try{
         const {email, password} = await req.json()
@@ -15,7 +15,8 @@ export async function GET(req: NextRequest) {
         if (!passwordsMatch){
             return NextResponse.json("Failed: Login Failed", {status: 400})
         }
-        return NextResponse.json({email});
+        console.log(email)
+        return NextResponse.json("Success: Login Complete");
     }
     catch (err) {
         return NextResponse.json(`${err}`, { status: 400 });

--- a/src/app/api/login/route.ts
+++ b/src/app/api/login/route.ts
@@ -6,16 +6,16 @@ const bcrypt = require("bcrypt");
 export async function GET(req: NextRequest) {
     await connectDB();
     try{
-        const {email, plain_text_password} = await req.json();
-        if (!email || !plain_text_password) {
+        const {email, password} = await req.json()
+        if (!email || !password) {
             return NextResponse.json("Failed: Login Incomplete", { status: 400 });
         }
         const user = await Users.findOne({email: email}).orFail();
-        const passwordsMatch = bcrypt.compareSync(plain_text_password, user.password);
+        const passwordsMatch = bcrypt.compareSync(password, user.password);
         if (!passwordsMatch){
-            return NextResponse.json("Failed: Login Failed")
+            return NextResponse.json("Failed: Login Failed", {status: 400})
         }
-        return NextResponse.json(email);
+        return NextResponse.json({email});
     }
     catch (err) {
         return NextResponse.json(`${err}`, { status: 400 });


### PR DESCRIPTION
## Developer: Aarav Sharma

Closes #42 

### Pull Request Summary

Adding the backend capability to handle login attempts. When the user enters their login information, the POST api endpoint uses the email they entered to compare the user's password attempt and the corresponding hashed password stored in the database. Used bcrypt for the comparing the entered plain text password and hashed password.

### Modifications

Created route.ts in src/app/api/login
- Added a POST API endpoint

### Testing Considerations

Tested endpoint using Postman

### Pull Request Checklist

- [X] Code is neat, readable, and works
- [X] Comments are appropriate
- [X] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [X] The developer name is specified
- [X] The summary is completed
- [X] Assign reviewers

### Screenshots/Screencast
<img width="1169" alt="Screenshot 2024-04-05 at 6 44 50 PM" src="https://github.com/hack4impact-calpoly/go-see-foundation/assets/43897253/56c81211-08ed-4826-8464-6982ef336015">
