### PR TITLE
Skip to content link

### DIFF
--- a/src/app/components/Navbar.tsx
+++ b/src/app/components/Navbar.tsx
@@ -7,9 +7,11 @@ import menu from "../images/menu.png";
 import styles from "./navbar.module.css";
 
 export default function Navbar() {
-
   return (
     <div className={styles.navbar}>
+      <a href="#about-us" className="skip-to-main-content-link">
+        Skip to end of navbar
+      </a>
       <div className={styles.mainbar}>
         <div className={styles.image}>
           <Image
@@ -63,11 +65,11 @@ export default function Navbar() {
           </Link>
         </div>
         <div className={styles.linkWrapper}>
-          <Link className={styles.link} href="/about">
+          <Link className={styles.link} href="/about" id="about-us">
             ABOUT US
           </Link>
-        </div> 
+        </div>
       </div>
-    </div> 
+    </div>
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -18,3 +18,18 @@ body {
 html {
   height: 100%;
 }
+
+.skip-to-main-content-link {
+  position: absolute;
+  left: -9999px;
+  z-index: 999;
+  padding: 1em;
+  background-color: black;
+  color: white;
+  opacity: 0;
+}
+.skip-to-main-content-link:focus {
+  left: 50%;
+  transform: translateX(-50%);
+  opacity: 1;
+}


### PR DESCRIPTION
## Developer: Angela Chen

Closes #65

### Pull Request Summary

Implement skip to main content link for screenreader users. -- hard to implement using a component structured-page because the main content of each page is different, so instead I skipped to the end of the nav bar which is the about us link

### Modifications

Navbar.tsx
globals.css (for button styling - invisible if no one hits tab)

### Testing Considerations

Entering tab should make the skip button visible, hitting enter should bring the focus to the end of the navbar (about us link). Hitting tab again instead of enter should just continue down the navbar as usual.

### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast
hit tab
![image](https://github.com/hack4impact-calpoly/go-see-foundation/assets/113945749/d09c8878-610c-4678-94e4-ce8e6fd53b52)

hit enter
![image](https://github.com/hack4impact-calpoly/go-see-foundation/assets/113945749/b6b5d337-13ef-4108-8b91-6586c3d5d3e5)

