### PR TITLE
170 focus on resource page

### DIFF
--- a/src/app/components/Resource.tsx
+++ b/src/app/components/Resource.tsx
@@ -34,7 +34,6 @@ export default function Resource({
     addRef(refIndex, refIndex + 1);
   }, []);
 
-  console.log("resource created");
   return (
     <div className={styles.container}>
       <Link
@@ -58,6 +57,7 @@ export default function Resource({
         className={styles.titleLink}
         id={`resource${refIndex + 1}`}
         ref={titleRef}
+        onKeyDown={refHandler}
       >
         <h3 className={styles.title}>{title}</h3>
       </Link>

--- a/src/app/components/Resource.tsx
+++ b/src/app/components/Resource.tsx
@@ -2,23 +2,63 @@ import { IResource } from "@database/resourceSchema";
 import styles from "./resource.module.css";
 import Image from "next/image";
 import Link from "next/link";
+import React from "react";
+import { RefObjectMap } from "app/resources/page";
+import { useRef, useEffect } from "react";
 
-export default function Resource({ resource }: { resource: IResource }) {
+export default function Resource({
+  resource,
+  refIndex,
+  setRefs,
+  refHandler,
+}: {
+  resource: IResource;
+  refIndex: number;
+  setRefs: React.Dispatch<
+    React.SetStateAction<RefObjectMap<HTMLAnchorElement>>
+  >;
+  refHandler: (e: React.KeyboardEvent<HTMLAnchorElement>) => void;
+}) {
   const { picture, alt, title, url } = resource;
+  const imageRef = useRef<HTMLAnchorElement>(null);
+  const titleRef = useRef<HTMLAnchorElement>(null);
+
+  useEffect(() => {
+    const addRef = (key1: number, key2: number) => {
+      setRefs((prevReferences) => ({
+        ...prevReferences,
+        [key1]: imageRef,
+        [key2]: titleRef,
+      }));
+    };
+    addRef(refIndex, refIndex + 1);
+  }, []);
+
   console.log("resource created");
   return (
     <div className={styles.container}>
-      <Link className={styles.pictureLink} href={url}>
+      <Link
+        className={styles.pictureLink}
+        href={url}
+        id={`resource${refIndex}`}
+        ref={imageRef}
+        onKeyDown={refHandler}
+      >
         <Image
           className={styles.picture}
           src={picture}
           alt={alt}
           width="1000"
           height="1000"
-        />{""}
-
+        />
+        {""}
       </Link>
-      <Link href={url} className={styles.titleLink}>
+      <Link
+        href={url}
+        className={styles.titleLink}
+        id={`resource${refIndex + 1}`}
+        ref={titleRef}
+      >
         <h3 className={styles.title}>{title}</h3>
       </Link>
     </div>

--- a/src/app/components/ResourceRow.tsx
+++ b/src/app/components/ResourceRow.tsx
@@ -1,18 +1,31 @@
 import { IResource } from "@database/resourceSchema";
 import styles from "./resourceRow.module.css";
 import Resource from "./Resource";
+import { RefObjectMap } from "app/resources/page";
 
 export default function ResourceRow({
   resources,
+  startIndex,
+  setRefs,
+  refHandler,
 }: {
   resources: Array<IResource>;
+  startIndex: number;
+  setRefs: React.Dispatch<
+    React.SetStateAction<RefObjectMap<HTMLAnchorElement>>
+  >;
+  refHandler: (e: React.KeyboardEvent<HTMLAnchorElement>) => void;
 }) {
-  console.log("making row");
-  console.log(resources);
   return (
     <div className={styles.resourceRow}>
       {resources?.map((single_resource: IResource, index: number) => (
-        <Resource key={index} resource={single_resource} />
+        <Resource
+          key={index}
+          resource={single_resource}
+          refIndex={startIndex + index * 2}
+          setRefs={setRefs}
+          refHandler={refHandler}
+        />
       ))}
     </div>
   );

--- a/src/app/resources/page.tsx
+++ b/src/app/resources/page.tsx
@@ -5,8 +5,42 @@ import ResourceRow from "@components/ResourceRow";
 import { IResource } from "@database/resourceSchema";
 import Image from "next/image";
 
+// define type for dynamic number of resource references (used in useRefs)
+export type RefObjectMap<T> = {
+  [key: string]: React.RefObject<T>;
+};
+
 export default function ResourcePage() {
   const [resources2D, setResources2D] = useState<Array<Array<IResource>>>([]);
+  const [count, setCount] = useState<number>(0);
+  const [references, setReferences] = useState<RefObjectMap<HTMLAnchorElement>>(
+    {}
+  );
+
+  const handleInputKeyPress = (e: React.KeyboardEvent<HTMLAnchorElement>) => {
+    if (e.key === "Tab") {
+      e.preventDefault();
+      console.log(`count: ${count}`);
+
+      let i = 0;
+      while (i < count) {
+        if (e.currentTarget.id === `resource${i}`) {
+          if (i === count - 1) {
+            console.log("at the end");
+            // at the end, loop back to start
+            references[0]?.current?.focus();
+          } else {
+            console.log("NOT at the end");
+            references[i + 1]?.current?.focus();
+            break;
+          }
+          i = count; // end loop
+        } else {
+          i++;
+        }
+      }
+    }
+  };
 
   useEffect(() => {
     const fetchResourceData = async () => {
@@ -26,6 +60,8 @@ export default function ResourcePage() {
           tempResources2D.push(row);
         }
         setResources2D(tempResources2D);
+        setCount(data.length * 2);
+
       } catch (err: unknown) {
         console.error(`Resources could not be fetched. Error: ${err}`);
       }
@@ -55,7 +91,13 @@ export default function ResourcePage() {
     <div className={styles.container}>
       <h2 className={styles.sectionHeader}>Resources</h2>
       {resources2D?.map((row: Array<IResource>, index: number) => (
-        <ResourceRow key={index} resources={row} />
+        <ResourceRow
+          key={index}
+          resources={row}
+          startIndex={index * 3 * 2}
+          setRefs={setReferences}
+          refHandler={handleInputKeyPress}
+        />
       ))}
       <h2 className={styles.sectionHeader} tabIndex={0}>
         Supporters

--- a/src/app/resources/page.tsx
+++ b/src/app/resources/page.tsx
@@ -20,11 +20,11 @@ export default function ResourcePage() {
   const handleInputKeyPress = (e: React.KeyboardEvent<HTMLAnchorElement>) => {
     if (e.key === "Tab") {
       e.preventDefault();
-      console.log(`count: ${count}`);
 
       let i = 0;
       while (i < count) {
         if (e.currentTarget.id === `resource${i}`) {
+          console.log(e.currentTarget.id);
           if (i === count - 1) {
             console.log("at the end");
             // at the end, loop back to start
@@ -32,7 +32,6 @@ export default function ResourcePage() {
           } else {
             console.log("NOT at the end");
             references[i + 1]?.current?.focus();
-            break;
           }
           i = count; // end loop
         } else {
@@ -61,7 +60,6 @@ export default function ResourcePage() {
         }
         setResources2D(tempResources2D);
         setCount(data.length * 2);
-
       } catch (err: unknown) {
         console.error(`Resources could not be fetched. Error: ${err}`);
       }


### PR DESCRIPTION
## Developer: Sean Nguyen

Closes #170 

### Pull Request Summary
Added focus styling for the resource page. This proved rather difficult since the page creates a dynamic amount of resources based on the database, using multiple components in the process.

The biggest challenge was that the main resource page needs access to the `useRef`s associated with each resource. However, since there is an arbitrary number of resource components, these `useRef`s cannot be hard-coded. Specific rules regarding React Hooks also prevented iteratively creating `useRef`s (i.e. can't just make them within a loop). This suggests that the `useRef`s need to be made within the `Resource` component itself, yet while also giving the main resource page access to all the `useRef`s.

My solution was to create a `useState` JS object holding all the `useRef`s. This object, along with the `handleInputKeyPress` function which cycles through the focus elements, is created within the main resource page and passed to each `Resource` component. Then, the `Resource` component creates its own `useRef`s, adds them as attributes to the `Link` element for the image and text, and updates the JS object with them. 

### Modifications
- `src/app/resource/page.tsx`
- `src/app/components/ResourceRow.tsx`
- `src/app/components/Resource.tsx`

### Testing Considerations
For some reason, appending new `useRef`s to the JS object is very slow, meaning it takes a long time for the resources to actually show up on the resource page. Commenting out line 34 (or the entire `useEffect` on line 26) in `src/app/components/Resource.tsx` makes the page load all the resource tiles significantly faster. Of course, this also prevents the focus styling on the page. I'm not sure why updating the `useState` results in such a performance difference :/

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers

### Screenshots/Screencast
![image](https://github.com/user-attachments/assets/fb39498b-6cd0-421a-a932-b5db93257558)

